### PR TITLE
feat(notebooks): add Linear Regression Pilot with ethical header + notebooks README

### DIFF
--- a/handbook/part-4-statistics-analysis/README.md
+++ b/handbook/part-4-statistics-analysis/README.md
@@ -43,7 +43,5 @@ Sound data analysis underpins credible conclusions. Plan your workflow before co
 If you are unsure about a statistical method, consult your tutor early or use the statistics help desks offered by the Faculty of Physics.
 
 ## Interactive Tutorial (Pilot)
-
-Use the acknowledgment splash before launching the environment:
-
+Launch the in-browser notebook via our splash page (acknowledgment required):  
 [Launch the Linear Regression Pilot](../../binder_splash/index.md)

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+This folder contains interactive tutorials used in the Advanced Lab Classes.
+Before running any notebook, please read and acknowledge the **Lab Alliance Compact (Part 0)**.
+
+- `linear_regression_with_uncertainty.ipynb` — Pilot tutorial:
+  - Weighted linear regression with `curve_fit`
+  - Uncertainties and confidence intervals
+  - Residual analysis and basic diagnostics

--- a/notebooks/linear_regression_with_uncertainty.ipynb
+++ b/notebooks/linear_regression_with_uncertainty.ipynb
@@ -2,18 +2,51 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "editable": false,
-    "deletable": false
-   },
+   "metadata": { "editable": false, "deletable": false },
    "source": [
-    "# Ethical Reminder\n",
-    "\n",
-    "This notebook follows the **Lab Alliance Compact**. Proceed only if you commit to:\n",
-    "\n",
-    "- Uphold data integrity: record results honestly and document processing steps.\n",
-    "- Credit original work: cite sources and acknowledge collaborators appropriately.\n",
-    "- Collaborate respectfully: communicate openly, share workload fairly, and seek help early when challenges arise."
+    "# Ethical Reminder (from the Lab Alliance Compact)
+",
+    "
+",
+    "- Data belongs to truth, not expectations; document steps transparently.
+",
+    "- Perform **your own analysis**; credit all sources and collaborators properly.
+",
+    "- Communicate respectfully; ask for help early; uphold psychological safety.
+",
+    "
+",
+    "> By proceeding, you acknowledge the Compact and agree to act accordingly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Linear Regression Pilot: Weighted Least Squares with Uncertainties
+",
+    "
+",
+    "**Learning goals**
+",
+    "1. Generate synthetic data with known ground truth.
+",
+    "2. Perform **weighted** linear regression using `scipy.optimize.curve_fit`.
+",
+    "3. Interpret fit parameters, standard errors, confidence intervals.
+",
+    "4. Diagnose fits via **residuals** and χ² per degree of freedom.
+",
+    "5. Understand the distinction between **statistical** and **systematic** uncertainties.
+",
+    "
+",
+    "**Model:**  $begin:math:text$ y = a x + b \$end:math:text$
+",
+    "
+",
+    "This pilot complements *Part 4 · Statistics & Data Analysis* in the handbook.
+"
    ]
   },
   {
@@ -22,9 +55,50 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "from scipy.optimize import curve_fit\n",
-    "import matplotlib.pyplot as plt"
+    "import numpy as np
+",
+    "import matplotlib.pyplot as plt
+",
+    "from scipy.optimize import curve_fit
+",
+    "rng = np.random.default_rng(42)
+",
+    "
+",
+    "def model(x, a, b):
+",
+    "    return a*x + b
+",
+    "
+",
+    "# --- Ground truth and synthetic data ---
+",
+    "a_true, b_true = 2.0, -1.0
+",
+    "N = 30
+",
+    "x = np.linspace(0, 10, N)
+",
+    "
+",
+    "# Heteroscedastic noise: sigma grows mildly with x
+",
+    "sigma = 0.2 + 0.02*x
+",
+    "y = model(x, a_true, b_true) + rng.normal(0.0, sigma)
+",
+    "
+",
+    "x[:5], y[:5], sigma[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize data with error bars
+",
+    "Always label axes with units (if applicable) and show uncertainties on measured points."
    ]
   },
   {
@@ -33,52 +107,16 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "rng = np.random.default_rng(42)\n",
-    "x = np.linspace(0, 10, 25)\n",
-    "true_m, true_b = 2.5, -1.0\n",
-    "stat_sigma = 0.6\n",
-    "systematic_offset = 0.3\n",
-    "noise = rng.normal(0, stat_sigma, size=x.size)\n",
-    "y = true_m * x + true_b + noise + systematic_offset\n",
-    "\n",
-    "stat_uncertainty = np.full_like(x, stat_sigma)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "def linear(x, m, b):\n",
-    "    return m * x + b\n",
-    "\n",
-    "popt, pcov = curve_fit(linear, x, y, sigma=stat_uncertainty, absolute_sigma=True)\n",
-    "perr = np.sqrt(np.diag(pcov))\n",
-    "print(f\"Slope: {popt[0]:.3f} \u00b1 {perr[0]:.3f}\")\n",
-    "print(f\"Intercept: {popt[1]:.3f} \u00b1 {perr[1]:.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "fit_y = linear(x, *popt)\n",
-    "residuals = y - fit_y\n",
-    "\n",
-    "fig, axes = plt.subplots(2, 1, figsize=(6, 8), sharex=True)\n",
-    "axes[0].errorbar(x, y, yerr=stat_uncertainty, fmt='o', label='Measurements')\n",
-    "axes[0].plot(x, fit_y, '-', label='Best-fit line')\n",
-    "axes[0].set_ylabel('y')\n",
-    "axes[0].legend()\n",
-    "\n",
-    "axes[1].axhline(0, color='k', linestyle='--')\n",
-    "axes[1].errorbar(x, residuals, yerr=stat_uncertainty, fmt='o')\n",
-    "axes[1].set_xlabel('x')\n",
-    "axes[1].set_ylabel('Residuals')\n",
-    "plt.tight_layout()\n",
+    "fig, ax = plt.subplots(figsize=(6,4))
+",
+    "ax.errorbar(x, y, yerr=sigma, fmt='o', capsize=3)
+",
+    "ax.set_xlabel('x')
+",
+    "ax.set_ylabel('y')
+",
+    "ax.set_title('Synthetic data with heteroscedastic noise')
+",
     "plt.show()"
    ]
   },
@@ -86,24 +124,194 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Discussion\n",
-    "\n",
-    "The statistical uncertainties (error bars) describe measurement scatter and inform the weighted fit.\n",
-    "The systematic offset of 0.3 introduces a bias in the intercept, visible in the residuals trending positive.\n",
-    "Further investigation could include independent calibration or control measurements to constrain systematic effects."
+    "## Weighted fit with `curve_fit`
+",
+    "`curve_fit` supports weights via `sigma` and `absolute_sigma=True`.
+",
+    "
+",
+    "- `sigma` = standard deviation (uncertainty) of each point.
+",
+    "- `absolute_sigma=True` tells `curve_fit` to treat these as **absolute** uncertainties.
+",
+    "- The returned covariance then reflects the scale of `sigma`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "p0 = [1.0, 0.0]  # initial guess [a, b]
+",
+    "popt, pcov = curve_fit(model, x, y, p0=p0, sigma=sigma, absolute_sigma=True)
+",
+    "a_fit, b_fit = popt
+",
+    "a_err, b_err = np.sqrt(np.diag(pcov))
+",
+    "print(f"Fit: a = {a_fit:.4f} ± {a_err:.4f}, b = {b_fit:.4f} ± {b_err:.4f}")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Goodness-of-fit and residuals
+",
+    "The **reduced** chi-squared $begin:math:text$ \chi^2_\nu \$end:math:text$ is informative:
+",
+    "$begin:math:display$ \chi^2 = \sum_i \frac{(y_i - f(x_i))^2}{\sigma_i^2}, \quad \chi^2_\nu = \chi^2/(N - p) \$end:math:display$
+",
+    "with $begin:math:text$N\$end:math:text$ data points and $begin:math:text$p\$end:math:text$ parameters (here, 2). Values near 1 suggest consistent uncertainties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "y_fit = model(x, *popt)
+",
+    "res = y - y_fit
+",
+    "chi2 = np.sum((res/sigma)**2)
+",
+    "ndof = len(x) - len(popt)
+",
+    "chi2_red = chi2/ndof
+",
+    "print(f"chi2 = {chi2:.2f}, ndof = {ndof}, chi2_red = {chi2_red:.2f}")
+",
+    "
+",
+    "fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6,6), sharex=True)
+",
+    "ax1.errorbar(x, y, yerr=sigma, fmt='o', capsize=3, label='data')
+",
+    "ax1.plot(x, y_fit, label='fit')
+",
+    "ax1.set_ylabel('y')
+",
+    "ax1.legend()
+",
+    "ax1.set_title('Fit and data')
+",
+    "
+",
+    "ax2.axhline(0, lw=1)
+",
+    "ax2.errorbar(x, res, yerr=sigma, fmt='o', capsize=3)
+",
+    "ax2.set_xlabel('x')
+",
+    "ax2.set_ylabel('residuals')
+",
+    "ax2.set_title('Residuals (with y-errors)')
+",
+    "plt.tight_layout()
+",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Confidence intervals
+",
+    "From the covariance matrix `pcov`, 1σ standard errors are:
+",
+    "$begin:math:display$ \sigma_a = \sqrt{\mathrm{cov}_{aa}}, \quad \sigma_b = \sqrt{\mathrm{cov}_{bb}}. \$end:math:display$
+",
+    "Approximate 95% CIs: $begin:math:text$ a \pm 1.96\,\sigma_a \$end:math:text$, $begin:math:text$ b \pm 1.96\,\sigma_b \$end:math:text$.
+",
+    "
+",
+    "We can also use a **bootstrap** to check robustness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def ci95(mu, sigma):
+",
+    "    return (mu - 1.96*sigma, mu + 1.96*sigma)
+",
+    "
+",
+    "ci_a = ci95(a_fit, a_err)
+",
+    "ci_b = ci95(b_fit, b_err)
+",
+    "print(f"95% CI (cov): a in [{ci_a[0]:.4f}, {ci_a[1]:.4f}], b in [{ci_b[0]:.4f}, {ci_b[1]:.4f}]")
+",
+    "
+",
+    "# --- Simple residual bootstrap ---
+",
+    "B = 500
+",
+    "a_boot = np.empty(B)
+",
+    "b_boot = np.empty(B)
+",
+    "for k in range(B):
+",
+    "    resampled = rng.choice(res, size=res.size, replace=True)
+",
+    "    y_boot = y_fit + resampled
+",
+    "    popt_b, pcov_b = curve_fit(model, x, y_boot, p0=popt, sigma=sigma, absolute_sigma=True)
+",
+    "    a_boot[k], b_boot[k] = popt_b
+",
+    "
+",
+    "a_mu, b_mu = np.mean(a_boot), np.mean(b_boot)
+",
+    "a_std, b_std = np.std(a_boot, ddof=1), np.std(b_boot, ddof=1)
+",
+    "print(f"Bootstrap mean±std: a = {a_mu:.4f}±{a_std:.4f}, b = {b_mu:.4f}±{b_std:.4f}")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting results
+",
+    "- If $begin:math:text$\chi^2_\nu\approx1\$end:math:text$, your point-wise uncertainties are broadly consistent.
+",
+    "- Compare covariance-based CIs with bootstrap spread; large discrepancies hint at model mismatch or non-Gaussian noise.
+",
+    "- **Systematic vs. statistical**: we modeled statistical noise only. Systematic effects (e.g., offset in instrument calibration) shift results *coherently* and must be analyzed from experimental context, **not** from deviation to literature values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises (short)
+",
+    "1. **Weighted vs unweighted**: Repeat the fit with `sigma=None`. Compare parameters, errors, and $begin:math:text$\chi^2_\nu\$end:math:text$.
+",
+    "2. **Outliers**: Add a single outlier (e.g., at the highest x). How do residuals and CIs change? Consider robust approaches.
+",
+    "3. **Systematic offset**: Add a constant offset to all y-values. Which parameter(s) change and why? How would you detect this experimentally?
+",
+    "4. **Prediction band**: Using the covariance, draw the 95% confidence band of the regression line. What assumptions are implicit?"
    ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3",
-   "language": "python"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11"
-  }
+  "kernelspec": { "display_name": "Python 3", "language": "python", "name": "python3" },
+  "language_info": { "name": "python", "pygments_lexer": "ipython3" }
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
## Summary
- add a notebooks README that highlights the new linear regression pilot tutorial
- replace the pilot notebook with the requested ethical reminder, weighted fit workflow, and exercises
- link the handbook statistics chapter to the pilot via the binder splash page

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4342f9f788333866662ba8002593b