### PR TITLE
fix: update Binder splash page with working launch URL

### DIFF
--- a/binder_splash/index.md
+++ b/binder_splash/index.md
@@ -7,4 +7,4 @@
 
 Click **Proceed** only if you acknowledge the Compact principles.
 
-[Proceed to Binder ➜](<INSERT_BINDER_URL_HERE>)
+[Proceed to Binder ➜](https://mybinder.org/v2/gh/uwarring82/adv-lab-handbook/main?filepath=notebooks/linear_regression_with_uncertainty.ipynb)


### PR DESCRIPTION
## Summary
- update the Binder splash button so it opens the Linear Regression Pilot notebook

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d43d1850248333bfd48d0f0d9a3f13