### PR TITLE
docs: add annotated references for statistics & error analysis (Parts 3 & 4)

### DIFF
--- a/handbook/part-4-statistics-analysis/README.md
+++ b/handbook/part-4-statistics-analysis/README.md
@@ -43,5 +43,24 @@ Sound data analysis underpins credible conclusions. Plan your workflow before co
 If you are unsure about a statistical method, consult your tutor early or use the statistics help desks offered by the Faculty of Physics.
 
 ## Interactive Tutorial (Pilot)
-Launch the in-browser notebook via our splash page (acknowledgment required):  
+Launch the in-browser notebook via our splash page (acknowledgment required):
 [Launch the Linear Regression Pilot](../../binder_splash/index.md)
+
+## Further Reading & References
+
+For those who wish to dive deeper into uncertainty propagation, fitting techniques, or statistical foundations, the following resources are recommended:
+
+- **A Brief Introduction to Error Analysis and Propagation** (Fantner, EPFL) — concise, student-level PDF on random vs. systematic errors and propagation rules.  
+  [Download PDF](https://www.epfl.ch/labs/lben/wp-content/uploads/2018/07/Error-Propagation_2013.pdf)
+
+- **Introduction to Error and Uncertainty** (Columbia Physics Lab Guide) — practical introduction for lab students; explains uncertainty propagation with real examples.  
+  [Download PDF](https://www.physics.columbia.edu/sites/default/files/content/Lab%20Resources/Lab%20Guide%201_%20Introduction%20to%20Error%20and%20Uncertainty.pdf)
+
+- **Propagation of Errors — Basic Rules** (University of Washington) — concise formulas for sums, products, and general functions.  
+  [Download PDF](https://courses.washington.edu/phys431/propagation_errors_UCh.pdf)
+
+- **Introduction to Statistics and Data Analysis for Physicists** (University of Siegen / DESY) — comprehensive notes covering significance tests, goodness-of-fit, and systematic uncertainties.  
+  [Download PDF](https://www-library.desy.de/preparch/books/vstatmp_engl.pdf)
+
+- **Open Textbook: Introduction to Statistics** (Open Textbook Library) — free online book for a broad statistics foundation beyond physics labs.  
+  [Access Online](https://open.umn.edu/opentextbooks/textbooks/introduction-to-statistics)

--- a/handbook/part-5-reports-presentations/README.md
+++ b/handbook/part-5-reports-presentations/README.md
@@ -15,6 +15,7 @@ Follow the **IMRaD** structure (Introduction, Methods, Results, Discussion) and 
 4. **Methods** – Experimental setup, calibration procedures, measurement strategy, data acquisition tools, and uncertainty estimation approach.
 5. **Results** – Present processed data with uncertainties, tables, figures, and statistical evaluations. Highlight comparisons with theory.
 6. **Discussion** – Interpret findings, assess systematic limitations, compare to literature values, and suggest improvements.
+   > **Tip:** For a deeper treatment of uncertainty propagation, statistical fitting, and significance testing, see the *Further Reading & References* section in **Part 4 · Statistics & Data Analysis**.
 7. **Conclusion & Outlook** – Concise summary and potential future work.
 8. **References** – Consistent citation style (APA, Harvard, numeric) using reliable sources (textbooks, peer-reviewed articles, datasheets).
 9. **Appendices** – Raw data tables, extended derivations, additional plots, code snippets, or detailed uncertainty budgets.


### PR DESCRIPTION
## Summary
- add a "Further Reading & References" section with annotated external resources to Part 4 · Statistics & Data Analysis
- cross-reference the new resources from Part 5 · Reports & Presentations with a contextual tip in the Discussion section

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d440a73d10833389caf2af9df9a032