### PR TITLE
Add emergency protective notice and interim support contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ description: >-
 icon: scale-unbalanced-flip
 ---
 
+# ⚠️ Protective Notice (Temporary)
+
+The **Lab Alliance Compact (Part 0)** and full ethical framework are under construction.  
+Until these protections are live, students should note the following:
+
+- **This handbook currently contains only technical/scientific guidance.**
+- **Ethical safeguards, student rights, and escalation protocols are pending.**
+- In case of conflicts, misconduct, or safety concerns, use the contacts below immediately.
+
+> Interim feedback on misconduct, conflicts, or safety concerns may be sent to:
+> fachschaft@physik.uni-freiburg.de (student council, confidential)
+> or fp@physik.uni-freiburg.de (course coordinators Christian Weiser & Ulrich Warring).
+
 # README
 
 ### Welcome

--- a/handbook/part-1-quickstart/README.md
+++ b/handbook/part-1-quickstart/README.md
@@ -32,13 +32,36 @@ A well-planned start prevents last-minute stress and ensures a productive lab we
 
 ## Communication & Support
 
-* **Course coordinator:** Ulrich Warring – ✉️ ulrich.warring@physik.uni-freiburg.de
-* **Organization team:** Christof Bartels, Christian Weiser
+* **Course coordinators:** Christian Weiser & Ulrich Warring – ✉️ fp@physik.uni-freiburg.de
+* **Organization team:** Christof Bartels
 * **Tutors:** Assigned per experiment; contact via ILIAS messaging or institutional email.
 
 For organizational or scheduling issues, contact the coordinator. Technical and experiment-specific questions should be directed to your tutor. When in doubt, ask early.
 
 ***
+
+## 🚨 Interim Support & Contact
+
+While the Lab Alliance Compact (Part 0) is being finalized, please use these interim support channels:
+
+- **Course coordinators (organizational issues, conflict mediation):**
+  Christian Weiser & Ulrich Warring — fp@physik.uni-freiburg.de
+
+- **Student council (peer representation, advocacy):**
+  Fachschaft Physik Freiburg — fachschaft@physik.uni-freiburg.de
+
+- **University Ombudsperson (independent conflict resolution):**  
+  [University Ombudsperson contact page](https://www.uni-freiburg.de/ombudsperson)
+
+- **University Security (urgent safety, after hours):**  
+  +49 761 203-2222
+
+---
+
+> An anonymous interim feedback channel is available:  
+> Anonymous feedback form coming soon — for now please use email above.
+
+---
 
 ## Useful links
 


### PR DESCRIPTION
## Summary
- add a temporary protective notice and interim feedback guidance to the GitBook landing page
- publish interim support and contact channels in the quick start guide while the Lab Alliance Compact is pending
- correct interim contact emails for the course coordinators and student council

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d446779ae88333bc218756caf33d31