### PR TITLE
Add Part 7 lab course overview and tutor boundaries guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,5 +11,12 @@
 * [Part 5 · Reports & Presentations](handbook/part-5-reports-presentations/README.md)
 * [Part 6 · FAQ & Best Practices](handbook/part-6-faq-bestpractices/README.md)
 * [Part 7 · Lab Courses](handbook/part-7-labcourses/README.md)
-  * [FP-I overview](handbook/part-7-labcourses/fp-i/README.md)
-  * [FP-II overview](handbook/part-7-labcourses/fp-ii/README.md)
+  * [Overview](handbook/part-7-labcourses/README.md)
+  * FP-I
+    * [Overview](handbook/part-7-labcourses/fp-i/README.md)
+  * FP-II
+    * [Overview](handbook/part-7-labcourses/fp-ii/README.md)
+  * FP-Edu
+    * [Overview](handbook/part-7-labcourses/fp-edu/README.md)
+* [Part 8 · Contributing](handbook/part-8-contributing/README.md)
+  * [Tutor’s Guide to Professional Boundaries](handbook/part-8-contributing/tutor-boundaries.md)

--- a/handbook/part-0-lab-alliance-compact/README.md
+++ b/handbook/part-0-lab-alliance-compact/README.md
@@ -86,12 +86,14 @@ Inclusivity, professionalism, continuous improvement through feedback.
 * This Compact is a **Sacred Document**. Changes require explicit approval by the **Ethical Review Board (ERB)**.
 * See: [ERB Charter Outline](../../governance/erb-charter-outline.md)
 
+---
+### For Tutors
+See the [Tutor’s Guide to Professional Boundaries](../part-8-contributing/tutor-boundaries.md) for expectations and rights.
+
 ## Acknowledgment
 
 By proceeding with the Advanced Lab Classes, you acknowledge that you have read and will uphold this Compact and are aware of support resources.
 
 Complete the [Student Acknowledgment](ACKNOWLEDGMENT.md) before accessing Part 1 materials.
-
-- **For tutors:** see the [Tutor’s Guide to Professional Boundaries](../part-8-contributing/tutor-boundaries.md).
 
 **Last Updated:** September 2025 • **Next Review:** September 2026

--- a/handbook/part-7-labcourses/README.md
+++ b/handbook/part-7-labcourses/README.md
@@ -1,2 +1,38 @@
-# Part 7 · Lab Courses
+# Part 7 · Lab Courses Overview
 
+The Advanced Laboratory Classes at the University of Freiburg are organized into several modules, each aligned with specific study programs. While the detailed selection of experiments and tasks may differ, the **overall structure, scientific guidelines, and expectations apply to all variants**.
+
+---
+
+## FP-I · Advanced Laboratory Course I
+- **Program**: B.Sc. Physics  
+- **Scope**: Introduction to advanced experimental techniques, measurement strategies, and data analysis.  
+- **ECTS**: 6 credits (see the official module handbook for the B.Sc. Physics program).  
+- **Content**: Students complete a set of experiments (typically 5–6) from core areas of modern physics.  
+- **Goal**: Establish a systematic approach to experiment design, uncertainty treatment, and scientific reporting.
+
+---
+
+## FP-II · Advanced Laboratory Course II
+- **Program**: M.Sc. Physics  
+- **Scope**: In-depth experimental investigations with more complex setups, often over multiple days.  
+- **ECTS**: 8 credits (see the official module handbook for the M.Sc. Physics program).  
+- **Content**: Students select advanced experiments (typically 4–5) from a broader catalog, with strong emphasis on independent preparation.  
+- **Goal**: Strengthen critical analysis, integration of theory and experiment, and advanced communication skills.
+
+---
+
+## FP-Edu · Advanced Laboratory Course for Master of Education
+- **Program**: Master of Education (Physics)  
+- **Scope**: Laboratory training tailored to future teachers, balancing advanced experiments with didactic reflection.  
+- **ECTS**: 6 credits (see the official module handbook for the M.Ed. Physics program).  
+- **Content**: Experiments are drawn from the FP catalog and supplemented with **specialized project work** aligned with teaching methodology and communication.  
+- **Goal**: Combine scientific rigor with pedagogical reflection, preparing students for effective physics teaching.  
+- **Specialized Projects**: Extended or specialized projects are an **integral part of FP-Edu** (not a separate course).
+
+---
+
+## General Remarks
+- **Common Guidelines**: All courses follow the principles in Parts 0–6: scientific honesty, careful documentation, and rigorous uncertainty treatment.  
+- **Experiment Selection**: The number and choice of experiments may differ by program, but **evaluation criteria and reporting standards are consistent**.  
+- **Rulebooks**: For credit points, prerequisites, and formal regulations, consult the official **module handbooks** and university study regulations.

--- a/handbook/part-7-labcourses/_template/README.md
+++ b/handbook/part-7-labcourses/_template/README.md
@@ -1,13 +1,25 @@
-# Experiment Template (Replace with experiment name)
+# [Experiment Title]
+
 ## Learning goals
 - …
+
 ## Pre-lab reading & safety
 - …
+
 ## Setup & calibration checklist
 - …
+
+## Measurement plan
+- …
+
 ## Data & analysis checkpoints
 - …
+
 ## Typical pitfalls
 - …
-## Example figures/tables to include
+
+## Figures/tables to include
+- …
+
+## References
 - …

--- a/handbook/part-7-labcourses/fp-edu/README.md
+++ b/handbook/part-7-labcourses/fp-edu/README.md
@@ -1,0 +1,9 @@
+# FP-Edu · Advanced Laboratory Course for Master of Education
+
+This section will host the FP-Edu experiment catalog and didactic tasks.
+- **Program**: Master of Education (Physics)  
+- **ECTS**: 6 (see module handbook)
+- **Planned content**: experiment list, **specialized projects** for didactic goals, reflection prompts.
+
+> **Propose a new experiment page:** copy the **Experiment Template** from  
+> `handbook/part-7-labcourses/_template/` into the corresponding FP folder and submit a PR.

--- a/handbook/part-7-labcourses/fp-i/README.md
+++ b/handbook/part-7-labcourses/fp-i/README.md
@@ -1,1 +1,9 @@
-> To propose a new experiment page, copy the **Experiment Template** from `part-7-labcourses/_template` and open a PR.
+# FP-I · Advanced Laboratory Course I
+
+This section will host the FP-I experiment catalog, requirements, and typical workflow.
+- **Program**: B.Sc. Physics  
+- **ECTS**: 6 (see module handbook)
+- **Planned content**: experiment list, scheduling notes, report expectations, typical pitfalls.
+
+> **Propose a new experiment page:** copy the **Experiment Template** from  
+> `handbook/part-7-labcourses/_template/` into the corresponding FP folder and submit a PR.

--- a/handbook/part-7-labcourses/fp-ii/README.md
+++ b/handbook/part-7-labcourses/fp-ii/README.md
@@ -1,1 +1,9 @@
-> To propose a new experiment page, copy the **Experiment Template** from `part-7-labcourses/_template` and open a PR.
+# FP-II · Advanced Laboratory Course II
+
+This section will host the FP-II experiment catalog, requirements, and typical workflow.
+- **Program**: M.Sc. Physics  
+- **ECTS**: 8 (see module handbook)
+- **Planned content**: experiment list, extended measurement strategies, advanced analysis hints.
+
+> **Propose a new experiment page:** copy the **Experiment Template** from  
+> `handbook/part-7-labcourses/_template/` into the corresponding FP folder and submit a PR.

--- a/handbook/part-8-contributing/tutor-boundaries.md
+++ b/handbook/part-8-contributing/tutor-boundaries.md
@@ -1,6 +1,28 @@
-# Tutor’s Guide to Professional Boundaries (Quick Reference)
-- **Enable, don’t replace** student work: advise on method; do not compute or write for students.
-- **Transparency:** log major guidance decisions (why/when intervention happens).
-- **Fair access:** equitable time/attention; publish contact/office-hour norms.
-- **Assessment firewall:** feedback focuses on improvement; grades follow published rubrics.
-- **Escalation:** surface conflict early; invite coordinator if misalignment persists.
+# Tutor’s Guide to Professional Boundaries
+
+Tutors play a central role in ensuring the integrity, fairness, and success of the Advanced Laboratory Classes. This guide sets **expectations** and **rights** for tutors, balancing responsibilities within the Lab Alliance Compact.
+
+---
+
+## Expectations for Tutors
+- **Enable, don’t replace** student work: advise on method; do not perform analyses or write reports for students.
+- **Transparency**: log major guidance decisions (why/when intervention happens).
+- **Fair access**: provide equitable time and attention across student groups.
+- **Assessment firewall**: give constructive feedback; grade strictly by published rubrics.
+- **Escalation**: surface conflicts early; involve coordinators or the ERB when needed.
+- **Inclusivity & safety**: foster respectful, inclusive lab culture and uphold safety protocols.
+
+## Rights of Tutors
+- **Respectful treatment** from students and staff; zero tolerance for harassment.
+- **Clear boundaries**: reasonable office hours/response windows; no 24/7 expectation.
+- **Support channels**: access to coordinators, ERB, and ombudsperson for conflict or undue pressure.
+- **Academic integrity**: right to refuse support for dishonest behavior, backed by policy.
+- **Professional development**: access to feedback, training, and recognition.
+
+---
+
+## Connection to the Lab Alliance Compact
+This guide complements **Part 0 · Lab Alliance Compact**.  
+- Students commit to respectful collaboration and fair treatment.  
+- Tutors commit to enabling learning while protecting professional boundaries.  
+Together, these ensure mutual accountability and a safe, productive learning environment.


### PR DESCRIPTION
## Summary
- add a unified overview of FP-I, FP-II, and FP-Edu lab courses
- scaffold FP-specific sections and provide a reusable experiment page template
- document tutor professional boundaries and link the guide from the Lab Alliance Compact
- update handbook navigation to include the new materials

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d4df830ed08333a3e04c0210d6c33a