### PR TITLE
Add Part 0 ethics and examination rules overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Until these protections are live, students should note the following:
 
 > Interim feedback on misconduct, conflicts, or safety concerns may be sent to: or fp@physik.uni-freiburg.de (course coordinators) or fachschaft@physik.uni-freiburg.de (student council, confidential)&#x20;
 
+> **Academic integrity & exams**  
+> The advanced lab classes are bound by the University of Freiburg’s integrity and examination regulations.  
+> See **[Part 0 — Ethics, Academic Integrity & Examination Rules](handbook/part0-ethics-exam-rules.md)** for the compact, procedures, and program-specific links (Physics B.Sc./M.Sc., Master of Education). The mandatory quiz is completed on **ILIAS** per program.
+
 ## Welcome
 
 Dear students and tutors,

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,8 @@
 * [Part 0 · Lab Alliance Compact](handbook/part-0-lab-alliance-compact/index.md)
   * [Acknowledgment](handbook/part-0-lab-alliance-compact/ACKNOWLEDGMENT.md)
   * [ERB Charter Outline](governance/erb-charter-outline.md)
+* [Part 0 – Ethics, Academic Integrity & Examination Rules](handbook/part0-ethics-exam-rules.md)
+  * [Pre-quiz self-check](handbook/assets/part0-checklist.md)
 * [Part 1 · Quick Start Guide & Navigation](handbook/part-1-quickstart/index.md)
 * [Part 2 · Organization & Framework](handbook/part-2-organization/index.md)
 * [Part 3 · Scientific Integrity & Lab Notes](handbook/part-3-integrity-labnotes/index.md)

--- a/handbook/assets/part0-checklist.md
+++ b/handbook/assets/part0-checklist.md
@@ -1,0 +1,16 @@
+# Part 0 — Pre-quiz self-check
+
+Tick through before taking the ILIAS quiz.
+
+1. I can name at least **three** forms of misconduct relevant to lab classes.  
+2. I understand how to **cite code** and external analysis tools properly.  
+3. Our team will keep a **lab notebook** and **git history** with meaningful commits.  
+4. Our reports will include **uncertainties/limitations** and not omit negative results.  
+5. We will **declare individual contributions** in group reports.  
+6. If we find post-submission errors, we will **notify instructors** and submit a **corrigendum**.
+
+**Acknowledgment** (paste in your lab log or cover sheet):  
+“I have reviewed the self-check and will complete the program-specific ILIAS quiz.”
+
+
+⸻

--- a/handbook/part0-ethics-exam-rules.md
+++ b/handbook/part0-ethics-exam-rules.md
@@ -1,0 +1,54 @@
+# Part 0 — Ethics, Academic Integrity & Examination Rules
+
+## 0.0 Legal & institutional basis
+These advanced lab courses are bound by the **University of Freiburg’s regulations on academic integrity** and the **study & examination regulations (SPO)** of the relevant programs. In case of any conflict, the **official statutes prevail**. Key references:
+- University of Freiburg, *Regulations on Safeguarding Academic Integrity* (English).  
+  (PDF)  
+- University page “Redlichkeit in der Wissenschaft” (Ombudsperson, process, contacts).  
+- Institute of Physics: “Redlichkeit in der Wissenschaft und gute wissenschaftliche Praxis” (overview, handout).  
+
+**Program statutes used by our cohorts:**
+- **Physics B.Sc. / (and MSc when available publicly):** Prüfungsordnung Physik (B.Sc., German, PDF).  
+- **Master of Education (teaching track):** Study & Examination Regulations (non-official consolidated text; General Part, German, PDF) and the FACE information pages.
+
+## 0.1 What constitutes misconduct (digest)
+Intentional or grossly negligent:
+- **Fabrication/falsification** of data or figures; selective reporting that misleads  
+- **Plagiarism** (text, code, images, analysis) or use of AI/assistive tools beyond the stated rules without disclosure  
+- **Unauthorized collaboration/tools**; commissioning third-party work  
+- **Omitting uncertainties/negative data** so as to misrepresent results  
+- **Duplicate/auto-plagiarized submissions** across courses without disclosure  
+Authoritative definitions and procedures are governed by the University regulation above.
+
+## 0.2 Lab-course good practice (minimum expectations)
+- **Cite everything** used: papers, datasets, **code**, algorithms, figures.  
+- Maintain a **lab notebook** and **git history**; commit significant steps.  
+- Report **uncertainties, limitations, and negative results** transparently.  
+- In group work, **state each member’s contributions** in the report.  
+- If you discover an error after submission, **notify instructors** and file a brief **corrigendum**.
+
+## 0.3 Reporting & procedure (short flow)
+Suspicion/concern → confidential **Ombudsperson** consultation → if substantiated, referral to the competent committee (e.g., exam board) → decision & possible sanctions under the SPO. Students have the **right to respond** and **appeal** within the formal process.
+
+## 0.4 Acknowledgment & ILIAS quiz
+Before working in the lab, students must:
+1) read this Part 0 and the linked institutional rules;  
+2) complete the **program-specific ILIAS quiz** (course page);  
+3) include the following statement (e.g. in the lab log or cover page):
+
+> “I confirm that I have read *Part 0 — Ethics, Academic Integrity & Examination Rules* and the linked regulations of the University of Freiburg and my degree program. I will adhere to these principles in my lab work.”
+
+For preparation, see the self-check: `../assets/part0-checklist.md`.
+
+## 0.5 Program-specific links (maintained by staff)
+- **Physics B.Sc.** — Prüfungsordnung Physik (German, PDF).  
+- **Physics M.Sc.** — *(Add official link when the faculty publishes/points to the current PDF; until then, rely on the faculty study pages.)*  
+- **Master of Education (teaching track)** — General Part (German, PDF); FACE information/contacts.  
+
+---
+### Link sources (for editors)
+- University Integrity Regulation (EN PDF).  
+- Ombudsperson page (“Redlichkeit in der Wissenschaft”).  
+- Institute overview page (EN/DE) + Handout (EN PDF).  
+- Physics B.Sc. Prüfungsordnung (DE PDF).  
+- M.Ed. General Part, non-official consolidated text (DE PDF) & FACE pages.  


### PR DESCRIPTION
## Summary
- add a Part 0 ethics, integrity, and examination rules page with references, good practice, and reporting guidance
- provide the accompanying pre-quiz self-check asset for students before the ILIAS quiz
- update the README callout and SUMMARY table of contents to surface the new material

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da268c182c8333998f19b34148e23c